### PR TITLE
use newer version of pypandoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 sudo: false
 language: python
-env:
-    - TOXENV=py26
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py35
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
 install:
     - pip install -r requirements.txt
 before_script:

--- a/pytest_github/plugin.py
+++ b/pytest_github/plugin.py
@@ -237,7 +237,7 @@ class GitHubPytestPlugin(object):
                     (username, repository, number) = self.__parse_issue_url(url)
                     try:
                         self._issue_cache[url] = self.api.issue(username, repository, number)
-                    except (AttributeError, github3.models.GitHubError) as e:
+                    except (AttributeError, github3.exceptions.GitHubError) as e:
                         errstr = "Unable to inspect github issue %s - %s" % (url, str(e))
                         warnings.warn(errstr, Warning)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ coveralls
 PyYAML
 mock
 pylama
-pylama_pylint
+pylama_pylint; python_version >= '2.7' and python_version < '2.8'

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     },
     # zip_safe=False,
     setup_requires=[
-        'pypandoc<1.2.0',
+        'pypandoc',
         'setuptools-markdown'
     ],
     tests_requires=[
@@ -114,10 +114,6 @@ setup(
         'pytest',
         'PyYAML',
         'github3.py',
-    ],
-    dependency_links=[
-        # 'git+ssh://git@github.com/github3py/github3.py@1.0.0a1#egg=github3py',
-        'git+https://github.com/github3py/github3.py@1.0.0a1#egg=github3.py',
     ],
     cmdclass={
         'test': ToxTestCommand,

--- a/tox.ini
+++ b/tox.ini
@@ -2,20 +2,17 @@
 distshare = {homedir}/.tox/distshare
 envlist =
     lint,
-    py26,
     py27,
     py33,
     py34,
     py35,
     coveralls
-skip_missing_interpreters = true
+skip_missing_interpreters = false
 # recreate = true
 # skipsdist = true
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-setenv =
-    PYTHONPATH = {toxinidir}:{env:PYTHONPATH:}:.
 deps =
     -r{toxinidir}/requirements.txt
 commands = coverage run --parallel --source pytest_github -m pytest --doctest-glob='*.md' {posargs}


### PR DESCRIPTION
related to #6

* <1.2.0 version of pypandoc relies on pandoc -h outputing a format
list. In newer versions of pandoc, the -h flag is for help
* The newer versions of pypandoc are aware of both the old pandoc
command line switches and the new ones.