### PR TITLE
Update --github-summary to show issue state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/pytest_github/plugin.py
+++ b/pytest_github/plugin.py
@@ -13,7 +13,6 @@ import yaml
 import pytest
 from _pytest.resultlog import generic_path
 import github3
-from github3.issues.issue import Issue
 
 # Import, or define, NullHandler
 try:

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -250,6 +250,8 @@ def test_param_github_summary_no_issues(testdir, capsys, closed_issues, open_iss
 
     stdout, stderr = capsys.readouterr()
     assert 'No github issues collected' in stdout
+    assert 'Resolved Issues' not in stdout
+    assert 'Unresolved Issues' not in stdout
 
 
 @pytest.mark.usefixtures('monkeypatch_github3')
@@ -276,3 +278,11 @@ def test_param_github_summary_multiple_issues(testdir, capsys, closed_issues, op
 
     stdout, stderr = capsys.readouterr()
     assert 'collected %s github issues' % len(closed_issues + open_issues) in stdout
+    assert 'Unresolved Issues' in stdout
+    assert 'Resolved Issues' in stdout
+    unresolved_text = stdout[stdout.index('Unresolved Issues'):stdout.index('Resolved Issues')]
+    resolved_text = stdout[stdout.index('Resolved Issues'):]
+    for issue in open_issues:
+        assert issue in unresolved_text
+    for issue in closed_issues:
+        assert issue in resolved_text


### PR DESCRIPTION
Updates the output of `--github-summary` to show two separate lists of issues - `Unresolved Issues` and `Resolved Issues`. Issues are deemed to be resolved if they are closed or contain a label specified by `--github-completed`. Also updates the output to sort the issues by issue number.

Sample output:
```
Unresolved Issues
https://github.com/pytest-github/open/issues/1
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_bar
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_baz
https://github.com/pytest-github/open/issues/2
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_bar
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_baz
https://github.com/pytest-github/open/issues/3
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_bar
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_baz

Resolved Issues
https://github.com/pytest-github/closed/issues/4
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_foo
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_baz
https://github.com/pytest-github/closed/issues/5
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_foo
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_baz
https://github.com/pytest-github/closed/issues/6
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_foo
 - test_param_github_summary_multiple_issues0/test_param_github_summary_multiple_issues.py:test_baz
```