### PR TITLE
Use completed_labels argument (instead of global variable)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
 install:
     - pip install -r requirements.txt
 before_script:

--- a/pytest_github/plugin.py
+++ b/pytest_github/plugin.py
@@ -226,7 +226,7 @@ class GitHubPytestPlugin(object):
         # Process parameters
         self.username = username
         self.password = password
-        self.completed_labels = GITHUB_COMPLETED_LABELS
+        self.completed_labels = completed_labels
 
         # Initialize github api connection
         self.api = github3.login(self.username, self.password)


### PR DESCRIPTION
`GITHUB_COMPLETED_LABELS` is currently used instead of the `completed_labels` argument passed to `GitHubPytestPlugin`'s constructor. 

The default value for `GITHUB_COMPLETED_LABELS` is `[]`. This has the effect of making all issues effectively unresolved. As a result, all github-marked tests are xpassed or xfailed (never passed or failed). This will mask any tests that should pass / fail after an issue has been resolved.