### PR TITLE
Feature target ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,23 @@ In this example, the ``SKIPPED`` outcome is used.
 test.py::test_will_skip SKIPPED
 ```
 
+In this example, the ``SKIPPED`` outcome is used.
+
+```
+test.py::test_will_skip SKIPPED
+```
+
+### Example: IDS
+
+The following example demonstrates a parametrize test that uses the ``github`` marker to influence the outcome of a subset of the known failing test.
+
+```python
+@pytest.mark.github('https://github.com/some/open/issues/1', ids=['even2', 'even4'])
+@pytest.mark.parametrize("count", [1, 2, 3, 4], ids=["odd1", "even2", "odd3", "even4"])
+def test_will_xfail(count):
+    assert count % 2
+```
+
 ### Summary of GitHub markers and their associated tests
 
 The `--github-summary` option lists all GitHub issues referenced by a `github` marker. The list is divided into two sections, `Resolved Issues` and `Unresolved Issues`, where an issue is considered resolved if it has one of the `GITHUB_COMPLETED` labels. Beneath each issue is a listing of all tests that reference the issue.

--- a/pytest_github/plugin.py
+++ b/pytest_github/plugin.py
@@ -247,6 +247,24 @@ class GitHubPytestPlugin(object):
         if 'github' not in item.keywords:
             return
 
+        github_marker = item.get_marker('github')
+
+        '''
+        github marker may specify ids=['foo', 'bar']. By specifying ids, only
+        test cases that match those ids will be considered by github marker
+        logic.
+        '''
+        github_marker_ids = github_marker.kwargs.get('ids', [])
+        if github_marker_ids:
+            param_marker = item.get_marker('parametrize')
+            param_marker_ids = []
+            if param_marker:
+                param_marker_ids = param_marker.kwargs.get('ids', [])
+            current_test_id = item.callspec.id
+
+            if current_test_id not in github_marker_ids:
+                return
+
         unresolved_issues = []
         issue_urls = item.funcargs["github_issues"]
         for issue_url in issue_urls:

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import pytest
+import mock
+
+
+@pytest.mark.github('https://github.com/ansible/awx/issues/2061', ids=['a', 'd'])
+@pytest.mark.parametrize("should_run", [False, True, True, False, True], ids=['a', 'b', 'c', 'd', 'e'])
+def test_xfail_particular_parametrize_test_ids(should_run):
+    if should_run is False:
+        assert False, "This test should have been marked xfail"

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -2,9 +2,19 @@
 import pytest
 import mock
 
+from _pytest.main import EXIT_OK
 
-@pytest.mark.github('https://github.com/ansible/awx/issues/2061', ids=['a', 'd'])
-@pytest.mark.parametrize("should_run", [False, True, True, False, True], ids=['a', 'b', 'c', 'd', 'e'])
-def test_xfail_particular_parametrize_test_ids(should_run):
-    if should_run is False:
-        assert False, "This test should have been marked xfail"
+
+@pytest.mark.usefixtures('monkeypatch_github3')
+def test_xfail_particular_parametrize_test_ids(testdir, capsys):
+    src = """
+        import pytest
+        @pytest.mark.github('https://github.com/ansible/awx/issues/2061', ids=['a', 'd'])
+        @pytest.mark.parametrize("should_run", [False, True, True, False, True], ids=['a', 'b', 'c', 'd', 'e'])
+        def test_xfail_particular_parametrize_test_ids(should_run):
+            if should_run is False:
+                assert False, "This test should have been marked xfail"
+    """
+    result = testdir.inline_runsource(src, *[''])
+    stdout, stderr = capsys.readouterr()
+    assert result.ret == EXIT_OK

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -9,12 +9,13 @@ from _pytest.main import EXIT_OK
 def test_xfail_particular_parametrize_test_ids(testdir, capsys):
     src = """
         import pytest
-        @pytest.mark.github('https://github.com/ansible/awx/issues/2061', ids=['a', 'd'])
-        @pytest.mark.parametrize("should_run", [False, True, True, False, True], ids=['a', 'b', 'c', 'd', 'e'])
-        def test_xfail_particular_parametrize_test_ids(should_run):
-            if should_run is False:
-                assert False, "This test should have been marked xfail"
+	@pytest.mark.github('https://github.com/some/open/issues/1', ids=['even2', 'even4'])
+	@pytest.mark.parametrize("count", [1, 2, 3, 4], ids=["odd1", "even2", "odd3", "even4"])
+	def test_will_xfail(count):
+	    assert count % 2
     """
     result = testdir.inline_runsource(src, *[''])
     stdout, stderr = capsys.readouterr()
     assert result.ret == EXIT_OK
+
+


### PR DESCRIPTION
Allow specifying `ids=['foo', 'bar']` in github marker so that only a subet of parametrized permutations can be targeted.