### PR TITLE
Update tests to use correct exit code

### DIFF
--- a/pytest_github/plugin.py
+++ b/pytest_github/plugin.py
@@ -307,7 +307,10 @@ class GitHubPytestPlugin(object):
                 if url is not None and url not in self._issue_cache:
                     (username, repository, number) = self.__parse_issue_url(url)
                     try:
-                        self._issue_cache[url] = IssueWrapper(self.api.issue(username, repository, number), self)
+                        if self.api:
+                            self._issue_cache[url] = IssueWrapper(self.api.issue(username, repository, number), self)
+                        else:
+                            raise AttributeError('No valid github session found to access private issue.')
                     except (AttributeError, github3.exceptions.GitHubError) as e:
                         errstr = "Unable to inspect github issue %s - %s" % (url, str(e))
                         warnings.warn(errstr, Warning)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -152,9 +152,7 @@ def test_with_malformed_issue_link(testdir, capsys, issue_url, expected_result):
         assert "Malformed github issue URL:" in stdout
 
 
-def test_with_private_issue_link(testdir, recwarn, capsys):
-    '''FIXME'''
-
+def test_with_private_issue_link(testdir, capsys):
     issue_url = 'https://github.com/github/github/issues/1'
     src = """
         import pytest
@@ -162,26 +160,12 @@ def test_with_private_issue_link(testdir, recwarn, capsys):
         def test_func():
             assert False
     """ % issue_url
-    with pytest.warns(None) as record:
-        result = testdir.inline_runsource(src)
-        assert result.ret == EXIT_TESTSFAILED
 
-    # check that warnings are present
-    assert len(record) > 0
-
-    # Assert the expected warning is present
-    found = False
-    expected_warning = "Unable to inspect github issue %s" % issue_url
-    for warning in record:
-        # check that the category matches
-        assert issubclass(warning.category, Warning)
-
-        # check that the message matches
-        if expected_warning in str(warning.message):
-            found = True
-
-    # Assert the warning was found
-    assert found, "Unable to find expected warning message - %s" % expected_warning
+    testdir.makepyfile(src)
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1)
+    lines = ' '.join(result.stdout.lines)
+    assert 'Unable to inspect github issue' in lines
 
 
 @pytest.mark.usefixtures('monkeypatch_github3')

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 import mock
-from _pytest.main import EXIT_OK, EXIT_NOTESTSCOLLECTED, EXIT_INTERRUPTED  # NOQA
+from _pytest.main import (
+    EXIT_NOTESTSCOLLECTED,
+    EXIT_USAGEERROR,
+)
 from . import assert_outcome
 
 
@@ -49,9 +52,8 @@ def test_plugin_markers(testdir):
 )
 def test_param_requires_value(testdir, required_value_parameter):
     '''Verifies failure when not providing a value to a required parameter'''
-
     result = testdir.runpytest(*[required_value_parameter])
-    assert result.ret == EXIT_INTERRUPTED
+    assert result.ret == EXIT_USAGEERROR
     result.stderr.fnmatch_lines([
         '*: error: argument %s: expected one argument' % required_value_parameter,
     ])


### PR DESCRIPTION
This fixes 4 of the 5 failing tests....

the 5th one is acting weird. Something is capturing the warning in such a way that I neither the `with pytest.warns...` nor the `recwarn` fixture are getting access to the warning, despite the fact that the warning is being emitted.

```
============================================================================ test session starts ============================================================================
platform linux2 -- Python 2.7.15, pytest-3.8.0, py-1.6.0, pluggy-0.7.1
ansible: 2.6.4
rootdir: /tmp/pytest-of-elijah/pytest-62/test_with_private_issue_link0, inifile:
plugins: ordering-0.5, mp-0.0.4, cov-2.6.0, ansible-2.0.1, pylama-7.4.3, github-0.0.10
collecting 1 item                                                                                                                                                           collected 0 github issues
collected 1 item                                                                                                                                                            
There should be 1 tests run.

test_with_private_issue_link.py .                                                                                                                                     [100%]

============================================================================= warnings summary ==============================================================================
/home/elijah/sfw/ansible/pytest-github/pytest_github/plugin.py:316: UserWarning: Unable to inspect github issue https://github.com/github/github/issues/1 - No valid github session found to access private issue.
  warnings.warn(errstr, UserWarning)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=================================================================== 1 passed, 1 warnings in 0.01 seconds ====================================================================
FAILED
```