### PR TITLE
Fix broken tests and update tests to run in py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,11 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.6
-      env: TOXENV=py36
+      env: TOXENV=py36 coveralls
+    - python: 3.6
+      env: TOXENV=lint
 install:
     - pip install -r requirements.txt
-before_script:
-    - TOXENV=lint tox
 script:
     - tox
-after_success:
-    - TOXENV=coveralls tox

--- a/pytest_github/plugin.py
+++ b/pytest_github/plugin.py
@@ -263,7 +263,6 @@ class GitHubPytestPlugin(object):
             errstr = "Malformed github issue URL: '%s'" % url
             raise Exception(errstr)
 
-
     def pytest_runtest_setup(self, item):
         """Handle github marker by calling xfail or skip, as needed."""
         log.debug("pytest_runtest_setup() called")
@@ -282,7 +281,7 @@ class GitHubPytestPlugin(object):
             param_marker = item.get_closest_marker('parametrize')
             param_marker_ids = []
             if param_marker:
-                param_marker_ids = param_marker.kwargs.get('ids', [])
+                param_marker_ids = param_marker.kwargs.get('ids', [])  # noqa F841
             current_test_id = item.callspec.id
 
             if current_test_id not in github_marker_ids:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tox
 pytest
 coverage
 coveralls
-PyYAML
-mock
-pylama
-pylama_pylint; python_version >= '2.7' and python_version < '2.8'
+PyYAML>=3.12
+github3.py
+flake8
+mock; python_version < '3.0'

--- a/setup.py
+++ b/setup.py
@@ -109,10 +109,11 @@ setup(
     ],
     tests_requires=[
         'tox',
+        'github3.py',
     ],
     install_requires=[
         'pytest',
-        'PyYAML',
+        'PyYAML>=3.12',
         'github3.py',
     ],
     cmdclass={
@@ -130,5 +131,5 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3'
-    ] + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.3 3.4 3.5".split()],
+    ] + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.6".split()],
 )

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -60,7 +60,7 @@ def test_collection_with_issues_in_multiple_modules(testdir, capsys, closed_issu
     }
 
     testdir.makepyfile(**test_modules)
-    
+
     result = testdir.runpytest_inprocess('--collectonly')
     stdout, stderr = capsys.readouterr()
 

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -1,21 +1,19 @@
 # -*- coding: utf-8 -*-
 import pytest
-import mock
-
 from _pytest.main import EXIT_OK
 
 
 @pytest.mark.usefixtures('monkeypatch_github3')
 def test_xfail_particular_parametrize_test_ids(testdir, capsys):
     src = """
-        import pytest
-	@pytest.mark.github('https://github.com/some/open/issues/1', ids=['even2', 'even4'])
-	@pytest.mark.parametrize("count", [1, 2, 3, 4], ids=["odd1", "even2", "odd3", "even4"])
-	def test_will_xfail(count):
-	    assert count % 2
+import pytest
+@pytest.mark.github('https://github.com/some/open/issues/1', ids=['even2', 'even4'])
+@pytest.mark.parametrize("count", [1, 2, 3, 4], ids=["odd1", "even2", "odd3", "even4"])
+def test_will_xfail(count):
+    assert count % 2
     """
-    result = testdir.inline_runsource(src, *[''])
+    result = testdir.inline_runsource(src)
     stdout, stderr = capsys.readouterr()
+    assert '2 xfailed' in stdout
+    assert '2 passed' in stdout
     assert result.ret == EXIT_OK
-
-

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import warnings
+
 import pytest
 
 try:
@@ -117,10 +119,12 @@ def test_param_empty_cfg(testdir, recwarn):
     # check that only one warning was raised
     assert len(recwarn) > 0
     # check that the category matches
-    record = recwarn.pop(Warning)
-    assert issubclass(record.category, Warning)
+    for warn_obj in recwarn.list:
+        assert isinstance(warn_obj, warnings.WarningMessage)
+    all_warnings = [str(warn.message) for warn in recwarn.list]
+    warning_messages = ' '.join(all_warnings)
     # check that the message matches
-    assert str(record.message).startswith("No github configuration found in file: ")
+    assert 'No github configuration found in file' in warning_messages
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,7 @@ distshare = {homedir}/.tox/distshare
 envlist =
     lint,
     py27,
-    py33,
-    py34,
-    py35,
+    py36,
     coveralls
 skip_missing_interpreters = false
 # recreate = true
@@ -18,14 +16,13 @@ deps =
 commands = coverage run --parallel --source pytest_github -m pytest --doctest-glob='*.md' {posargs}
 
 [testenv:lint]
-basepython = python2.7
+basepython = python3.6
 commands =
-    - py.test pytest_github --flake8 {posargs}
-    - py.test pytest_github --pylama {posargs}
+    - flake8 {posargs}
     - coverage erase
 
 [testenv:coveralls]
-basepython = python2.7
+basepython = python3.6
 commands=
     - coverage combine
     - coverage report -m


### PR DESCRIPTION
Also fixup linter to run in py3 and update some formatting, update linters to run in py3 by default as py27 EOL is on its way. 

Attempting to address "insecure dependency" warning on https://requires.io/github/jlaska/pytest-github/requirements/?branch=master by updating version of pyYAML :man_shrugging: 