### PR TITLE
Fix yaml.load warning

### DIFF
--- a/pytest_github/plugin.py
+++ b/pytest_github/plugin.py
@@ -116,7 +116,7 @@ def pytest_configure(config):
         if os.path.isfile(github_cfg_file):
             # Load configuration file ...
             with open(github_cfg_file, 'r') as fd:
-                github_cfg = yaml.load(fd)
+                github_cfg = yaml.load(fd, Loader=yaml.FullLoader)
 
             if isinstance(github_cfg, dict) and 'github' in github_cfg and isinstance(github_cfg['github'], dict):
                 github_username = github_cfg['github'].get('username', None)


### PR DESCRIPTION
Fix yaml.load warning.

See: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation