### PR TITLE
Fix warning about yaml load

### DIFF
--- a/pytest_github/plugin.py
+++ b/pytest_github/plugin.py
@@ -116,7 +116,7 @@ def pytest_configure(config):
         if os.path.isfile(github_cfg_file):
             # Load configuration file ...
             with open(github_cfg_file, 'r') as fd:
-                github_cfg = yaml.load(fd)
+                github_cfg = yaml.safe_load(fd)
 
             if isinstance(github_cfg, dict) and 'github' in github_cfg and isinstance(github_cfg['github'], dict):
                 github_username = github_cfg['github'].get('username', None)


### PR DESCRIPTION
Fixes

```
12:59:41  /home/ec2-user/venvs/venv/lib64/python3.6/site-packages/pytest_github/plugin.py:119: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```