### PR TITLE
Pin pypandoc to < 1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     },
     # zip_safe=False,
     setup_requires=[
-        'pypandoc',
+        'pypandoc<1.8',
         'setuptools-markdown'
     ],
     tests_requires=[


### PR DESCRIPTION
we are using deprecated code removed in https://github.com/NicklasTegner/pypandoc/pull/257

Signed-off-by: Julen Landa Alustiza <jlanda@redhat.com>