### PR TITLE
Generalize the types of errors caught

### DIFF
--- a/pytest_github/plugin.py
+++ b/pytest_github/plugin.py
@@ -333,7 +333,7 @@ class GitHubPytestPlugin(object):
                             self._issue_cache[url] = IssueWrapper(self.api.issue(username, repository, number), self)
                         else:
                             raise AttributeError('No valid github session found to access private issue.')
-                    except (AttributeError, github3.exceptions.GitHubError) as e:
+                    except (AttributeError, github3.exceptions.GitHubException) as e:
                         errstr = "Unable to inspect github issue %s - %s" % (url, str(e))
                         warnings.warn(errstr, Warning)
 


### PR DESCRIPTION
I'm somewhat-frequently seeing this as a result of github flake.

```
E               File "/home/ec2-user/venvs/test-controller/lib64/python3.9/site-packages/pluggy/_callers.py", line 39, in _multicall
E                 res = hook_impl.function(*args)
E               File "/home/ec2-user/venvs/test-controller/lib64/python3.9/site-packages/pytest_github/plugin.py", line 333, in pytest_itemcollected
E                 self._issue_cache[url] = IssueWrapper(self.api.issue(username, repository, number), self)
E               File "/home/ec2-user/venvs/test-controller/lib64/python3.9/site-packages/github3/github.py", line 1176, in issue
E                 json = self._json(self._get(url), 200)
E               File "/home/ec2-user/venvs/test-controller/lib64/python3.9/site-packages/github3/models.py", line 216, in _get
E                 return self._request("get", url, **kwargs)
E               File "/home/ec2-user/venvs/test-controller/lib64/python3.9/site-packages/github3/models.py", line 206, in _request
E                 raise exceptions.ConnectionError(exc)
E             github3.exceptions.ConnectionError: <class 'requests.exceptions.ReadTimeout'>: A connection-level exception occurred: HTTPSConnectionPool(host='api.github.com', port=443): Read timed out. (read timeout=10)
E           assert False
```

If you consult the library used for `github3`, you can see that the `ConnectionError` is not a subclass of `github3.exceptions.GitHubError` which is what is currently caught.

This results in the test run being aborted with this error and something about an "internal error" in pytest. It also causes the pytest-mp to collect an inconsistent number of tests, which I can't fully understand now.

```
>>> import github3
>>> issubclass(github3.exceptions.ConnectionError, github3.exceptions.GitHubException)
True
>>> issubclass(github3.exceptions.GitHubError, github3.exceptions.GitHubException)
True
```

This change should catch both scenarios.